### PR TITLE
[Fix] Camera pivot height initialization on model not consistent

### DIFF
--- a/Assets/Scripts/CameraHandler.cs
+++ b/Assets/Scripts/CameraHandler.cs
@@ -77,20 +77,20 @@ namespace DNA
             _cameraTransform.position = new Vector3(0, 0, -3.5f);
             _cameraTransform.rotation = Quaternion.Euler(new Vector3(-10, 0, 0));
 
-            CharacterController controller = _targetTransform.GetComponent<CharacterController>();
-            _cameraPivotYOffset = controller.height - _CameraPivotYOffsetConstant;
-
-            _cameraPivotTransform.position = new Vector3(0, _cameraPivotYOffset, -0.025f);
             _defaultPosition = _cameraTransform.localPosition.z;
             _ignoreLayers = ~(1 << 8 | 1 << 11 | 1 << 10);
             _inputHandler = FindObjectOfType<InputHandler>();
-            _playerManager = FindObjectOfType<PlayerManager>();
             Cursor.lockState = CursorLockMode.Locked;
         }
 
         private void Start()
         {
             _environmentLayer = LayerMask.NameToLayer("Floor");
+
+            _playerManager = FindObjectOfType<PlayerManager>();
+            CharacterController controller = _targetTransform.GetComponent<CharacterController>();
+            _cameraPivotYOffset = controller.height - _CameraPivotYOffsetConstant;
+            _cameraPivotTransform.position = new Vector3(-0.025f, _cameraPivotYOffset, -0.025f);
         }
 
         public void FollowTarget(float delta)

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -19,14 +19,18 @@ namespace DNA
         private const float _defaultRadius = 0.2f;
 
 
-        void Start()
+        private void Awake()
         {
             _inputHandler = GetComponent<InputHandler>();
             _anim = GetComponentInChildren<Animator>();
-            _cameraHandler = CameraHandler.singleton;
             _playerMovement = GetComponent<PlayerMovement>();
 
             InitializeCharacterController();
+        }
+
+        void Start()
+        {
+            _cameraHandler = CameraHandler.singleton;
         }
 
         void Update()


### PR DESCRIPTION
# **Describe the changes**

> Please check one or more that apply to this pull request

* [ ] Feature
* [x] Bug fix
* [ ] Refactor (no functional changes)
* [ ] Other (include details)

> What has changed and how did you do it?

Depending on the model set as target transform of the Camera Holder, the height of the Camera Pivot was sometimes set to 2 - `_CameraPivotYOffsetConstant` where 2 is the default height of a `CharacterController` in Unity. In the other case, the height of the pivot was set to the computed `CharacterController` height from the 3D model - `_CameraPivotYOffsetConstant` as intended.

So, sometimes the Camera Pivot height was set before the computation of the `CharacterController` height from the 3D model. To correct this problem, the Camera Pivot height is now set in the `Start` function of the `CameraHandler` and the initialization of the `PlayerManager` is now in an `Awake` function apart from the Camera Handler initialization, which is still in the `Start` function of the `PlayerManager`.

# **References**

None.
