### PR TITLE
Only allow walk when not stepping and not dashing

### DIFF
--- a/Assets/Scripts/Movements/WalkAndRun.cs
+++ b/Assets/Scripts/Movements/WalkAndRun.cs
@@ -72,11 +72,13 @@ namespace DNA
             {
                 _movementData._controller.Move(new Vector3(_movementData._horizontalVelocity.x, _movementData._verticalVelocity, _movementData._horizontalVelocity.z) * delta);
             }
+            
             if (_movementData._isDashing)
             {
                 _movementData._controller.Move(_movementData._dashVelocity * delta);
             }
-            else
+
+            if (!_movementData._isStepping && !_movementData._isDashing)
             {
                 _movementData._controller.Move(_movementData._moveDirection.normalized * (speed * _movementData._speedModulation * delta) + new Vector3(0.0f, _movementData._verticalVelocity, 0.0f) * delta);
             }


### PR DESCRIPTION
# **Describe the changes**

> Please check one or more that apply to this pull request

* [ ] Feature
* [x] Bug fix
* [ ] Refactor (no functional changes)
* [ ] Other (include details)

> What has changed and how did you do it?

* Seen behavior: Player can slighty influence direction during front/back/side steps
* Expected behavior: Player retrieve move direction control at the end of the front/back/side steps
* Cause: If the player is stepping, it could enter the else of the dashing condition. The dash works properly, only allowing dash movement or exclusively walk/run movement.
* Fix: Only allow walk/run movement when not stepping and not dashing.

# **References**

None.
