### PR TITLE
[Fix] Disable horizontal input rotation for steps when locking

### DIFF
--- a/Assets/Data/PlayerMovementData.cs
+++ b/Assets/Data/PlayerMovementData.cs
@@ -80,6 +80,7 @@ namespace DNA
         public Vector2 _stepMovementInput;
         [SerializeField]
         public Vector2 _currentStepMovementInput;
+        public float _stepInitialHorizontalValue;
 
         public readonly float _StepPowerMultiplier = 100f;
         public readonly float _OrthogonalStepInputThreshold = 0.9f;

--- a/Assets/Scripts/Movements/Step.cs
+++ b/Assets/Scripts/Movements/Step.cs
@@ -149,6 +149,7 @@ namespace DNA
                 {
                     _movementData._isDashing = false;
                     _movementData._isStepping = true;
+                    _movementData._stepInitialHorizontalValue = _movementData._inputHandler.Horizontal;
                     _movementData._animatorHandler.PlayAnimation(_movementData._animatorHandler.StepString, true);
                 }
             }

--- a/Assets/Scripts/Movements/WalkAndRun.cs
+++ b/Assets/Scripts/Movements/WalkAndRun.cs
@@ -114,7 +114,7 @@ namespace DNA
             {
                 targetDirection = (_movementData._cameraHandler.CurrentLockTarget.transform.position - transform.position);
                 Vector3 perpendicularVector = Vector3.Cross(targetDirection, Vector3.up);
-                targetDirection += -perpendicularVector * _movementData._inputHandler.Horizontal;
+                targetDirection += -perpendicularVector * _movementData._stepInitialHorizontalValue;
             }
             else if (_movementData._isDashing)
             {


### PR DESCRIPTION
# **Describe the changes**

> Please check one or more that apply to this pull request

* [ ] Feature
* [x] Bug fix
* [ ] Refactor (no functional changes)
* [ ] Other (include details)

> What has changed and how did you do it?

When locking and stepping, the character should not rotate according to user input, the character should face the lock target.
Now we use a step initial horizontal value that is the same during all the step action instead of directly using the input horizontal value that can vary if the player tilt the stick.

**TO MERGE BEFORE THE PROJECT UPDATE**

# **References**

None.
